### PR TITLE
Fix typo in common.yaml

### DIFF
--- a/data/common.yaml
+++ b/data/common.yaml
@@ -35,7 +35,7 @@ proftpd::default_options:
   'ROOT':
     'ServerName': "ProFTPD server %{facts.networking.fqdn}"
     'ServerIdent': 'on "FTP Server ready."'
-    'ServerAdmin': "root@%{fact.networking.domain}"
+    'ServerAdmin': "root@%{facts.networking.domain}"
     'DefaultServer': 'on'
     'DefaultRoot': '~ !adm'
     'AuthPAMConfig': 'proftpd'


### PR DESCRIPTION
There was a typo which leads to a compile error on puppet8 and strcit_variables set to true.